### PR TITLE
Add option to request png image for GO plot

### DIFF
--- a/QRePS/stattest_metrics.py
+++ b/QRePS/stattest_metrics.py
@@ -496,7 +496,7 @@ def QRePS(args):
 
     ################# GO
         if genes['Gene'].count() > 0:
-            logging.info('{} gene(s) available for GO enrichment analysis'.format(genes['Gene'].count()))
+            logging.info('%s gene(s) available for GO enrichment analysis', genes['Gene'].count())
             if args.goplot_format in ('both', 'svg'):
                 filename = path.join(args.output_dir, 'GO_network_{}.svg'.format(sample_type.replace(',', '_')))
                 show_string_picture(genes['Gene'], filename, args.species, 'svg')

--- a/QRePS/stattest_metrics.py
+++ b/QRePS/stattest_metrics.py
@@ -318,10 +318,9 @@ def de_gene_list(df, method, reg_type, fold_change = 2, alpha = 0.01):
                                                 ) ]
     return res[['fold_change', '-log10(fdr_BH)', 'Gene']]
 
-def show_string_picture(genes, filename, species):
+def show_string_picture(genes, filename, species, output_format="svg"):
     genes = genes.dropna(axis = 0)
     string_api_url = "https://string-db.org/api/"
-    output_format = "svg"
     method = "network"
     request_url = string_api_url + output_format + "/" + method
     params = {
@@ -492,8 +491,12 @@ def QRePS(args):
     ################# GO
         if genes['Gene'].count() > 0:
             logging.info('{} gene(s) available for GO enrichment analysis'.format(genes['Gene'].count()))
-            filename = path.join(args.output_dir, 'GO_network_{}.svg'.format(sample_type.replace(',', '_')))
-            show_string_picture(genes['Gene'], filename, args.species)
+            if args.goplot_format in ('both', 'svg'):
+                filename = path.join(args.output_dir, 'GO_network_{}.svg'.format(sample_type.replace(',', '_')))
+                show_string_picture(genes['Gene'], filename, args.species, 'svg')
+            if args.goplot_format in ('both', 'png'):
+                filename = path.join(args.output_dir, 'GO_network_{}.png'.format(sample_type.replace(',', '_')))
+                show_string_picture(genes['Gene'], filename, args.species, 'highres_image')
             response = load_go_enrichment(genes['Gene'], args.species)
             if response:
                 go_res = pd.read_table(io.StringIO(response.text))
@@ -527,6 +530,7 @@ def main():
     pars.add_argument('--thresholds', choices = ['static', 'semi-dynamic', 'dynamic', 'ms1'], help = 'DE thresholds method.')
     pars.add_argument('--regulation', choices = ['UP', 'DOWN', 'all'], help = 'Target group of DE proteins.')
     pars.add_argument('--species', default = '9606', help = 'NCBI species identifier. Default value 9606 (H. sapiens).')
+    pars.add_argument('--goplot-format', default = 'svg', help = 'GO plot output format. Options: "svg", "png", "both", "none". Default: "svg"')
     pars.add_argument('--fold-change', type = float, default = 2, help = 'Fold change threshold.')
     pars.add_argument('--alpha', type = float, default = 0.01, help = 'False discovery rate threshold.')
     pars.add_argument('--fasta-size', type = float, default = 20417, help = 'Number of proteins in database for enrichment calculation.')

--- a/QRePS/stattest_metrics.py
+++ b/QRePS/stattest_metrics.py
@@ -530,7 +530,7 @@ def main():
     pars.add_argument('--thresholds', choices = ['static', 'semi-dynamic', 'dynamic', 'ms1'], help = 'DE thresholds method.')
     pars.add_argument('--regulation', choices = ['UP', 'DOWN', 'all'], help = 'Target group of DE proteins.')
     pars.add_argument('--species', default = '9606', help = 'NCBI species identifier. Default value 9606 (H. sapiens).')
-    pars.add_argument('--goplot-format', default = 'svg', help = 'GO plot output format. Options: "svg", "png", "both", "none". Default: "svg"')
+    pars.add_argument('--goplot-format', choices = ['svg', 'png', 'both', 'none'], help = 'GO plot output format. Default: "svg"')
     pars.add_argument('--fold-change', type = float, default = 2, help = 'Fold change threshold.')
     pars.add_argument('--alpha', type = float, default = 0.01, help = 'False discovery rate threshold.')
     pars.add_argument('--fasta-size', type = float, default = 20417, help = 'Number of proteins in database for enrichment calculation.')

--- a/README.md
+++ b/README.md
@@ -32,15 +32,15 @@ pip install git+https://github.com/kazakova/Metrics
 ```
 ## Usage
 ```
-qreps [-h]
+usage: qreps [-h]
              (--sample-file SAMPLE_FILE | --quantitation-file QUANTITATION_FILE | --ms1-file MS1_FILE)
              [--pattern PATTERN] [--labels LABELS [LABELS ...]]
              [--input-dir INPUT_DIR] [--output-dir OUTPUT_DIR]
              [--imputation {kNN,MinDet}] [--max-mv MAX_MV]
              [--thresholds {static,semi-dynamic,dynamic,ms1}]
              [--regulation {UP,DOWN,all}] [--species SPECIES]
-             [--fold-change FOLD_CHANGE] [--alpha ALPHA]
-             [--fasta-size FASTA_SIZE] [--report REPORT]
+             [--goplot-format GOPLOT_FORMAT] [--fold-change FOLD_CHANGE]
+             [--alpha ALPHA] [--fasta-size FASTA_SIZE] [--report REPORT]
 
 options:
   -h, --help            show this help message and exit
@@ -57,12 +57,15 @@ options:
                         Directory to store the results. Default value is current directory.
   --imputation {kNN,MinDet}
                         Missing value imputation method.
-  --max-mv MAX_MV       Maximum ratio of missing values. Default value is 0.5.
+  --max-mv MAX_MV       Maximum ratio of missing values.
   --thresholds {static,semi-dynamic,dynamic,ms1}
                         DE thresholds method.
   --regulation {UP,DOWN,all}
                         Target group of DE proteins.
   --species SPECIES     NCBI species identifier. Default value is 9606 (H. sapiens).
+  --goplot-format GOPLOT_FORMAT
+                        GO plot output format. Options: "svg", "png", "both",
+                        "none". Default: "svg"
   --fold-change FOLD_CHANGE
                         Fold change threshold.
   --alpha ALPHA         False discovery rate threshold.

--- a/test/test.py
+++ b/test/test.py
@@ -24,7 +24,7 @@ class QRePSResultTest(unittest.TestCase):
                 os.path.dirname(os.path.dirname(os.path.abspath(__file__))), 'example_1')
 
         with TemporaryDirectory() as tmpdir:
-            args = argparse.Namespace(sample_file=os.path.join(datadir, 'a172_dbtrg_sample.csv'), labels=['DBTRG_I,DBTRG_K','A172_I,A172_K'], input_dir=datadir, output_dir=tmpdir, imputation='kNN', thresholds='dynamic', regulation='UP', pattern = '_protein_groups.tsv', species = '9606', fold_change=2, alpha=0.01, fasta_size = 20417, report = False, ms1_file = False, max_mv = 0.5)
+            args = argparse.Namespace(sample_file=os.path.join(datadir, 'a172_dbtrg_sample.csv'), labels=['DBTRG_I,DBTRG_K','A172_I,A172_K'], input_dir=datadir, output_dir=tmpdir, imputation='kNN', thresholds='dynamic', regulation='UP', pattern = '_protein_groups.tsv', species = '9606', fold_change=2, alpha=0.01, fasta_size = 20417, report = False, ms1_file = False, max_mv = 0.5, goplot_format="svg")
             self.quants, self.gos, self.metrics = QRePS(args)
         for i in range(2):
             q = self.quants[i]


### PR DESCRIPTION
Added argument `--goplot-format`, to allow choice of go plot output format. svg for .svg (default), png for highres png image, both for both and none for no output image.

README is adjusted to mirror the presence of new argument